### PR TITLE
feat(ssh): Use ssh-agent instead of private_key

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -13,7 +13,7 @@ resource "scaleway_server" "k8s_master" {
   connection {
     type        = "ssh"
     user        = "root"
-    private_key = "${file(var.private_key)}"
+    agent       = true
   }
   provisioner "file" {
     source      = "scripts/"

--- a/nodes.tf
+++ b/nodes.tf
@@ -13,7 +13,7 @@ resource "scaleway_server" "k8s_node" {
   connection {
     type        = "ssh"
     user        = "root"
-    private_key = "${file(var.private_key)}"
+    agent       = true
   }
   provisioner "file" {
     source      = "scripts/docker-install.sh"


### PR DESCRIPTION
This fixes the following issue when using a password protected private key :
```
password protected keys are not supported. Please decrypt the key prior to use.
```
